### PR TITLE
Icon directory missed from build.properties.

### DIFF
--- a/plugin/build.properties
+++ b/plugin/build.properties
@@ -3,4 +3,5 @@ output.. = classes/
 bin.includes = plugin.xml,\
                META-INF/,\
                .,\
-               lib/code.satyagraha.gfm.viewer.ext-deps-1.2.1-SNAPSHOT.jar
+               lib/code.satyagraha.gfm.viewer.ext-deps-1.2.1-SNAPSHOT.jar,\
+               icons/


### PR DESCRIPTION
The Icon directory was not part of the build. So no icons will be shown in installation from updatesite.
